### PR TITLE
Adds userlist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These tools are used to display status information of our hackerspace.
 There's a simple Python script that generates a HTML page from a jinja2 template
 and a script aggregating the status JSON from a WiFi router.
 
-`connected_devices` and `generate_spaceapi` run on a WiFi router and collect 
+`connected_devices`, `connected_users` and `generate_spaceapi` run on a WiFi router and collect 
 information about the devices in our WiFi network to tell wether someone is 
 connected and thus the space is open. This is of course just an approximation 
 but it's cheap and works pretty well with a low DHCP lease time.

--- a/connected_users
+++ b/connected_users
@@ -1,0 +1,27 @@
+#!/bin/ash
+
+# DHCP leasefile of OpenWRT, option in /etc/config/dhcp
+DHCP=/tmp/dhcp.leases
+
+# Userlist
+# aa:bb:cc:dd:ee:ff Nickname
+USERLIST=userlist.txt
+
+while read LINE; do
+
+    MAC=$(echo $LINE | cut -d' ' -f 2)
+
+    while read LINE2; do
+
+                MAC2=$(echo $LINE2|cut -d' ' -f 1)
+                NAME=$(echo $LINE2|cut -d' ' -f 2)
+                if [ "$MAC" == "$MAC2" ] && $(echo $USERS | grep -v -q "\"$NAME\""); then
+                            USERS="\"$NAME\", ${USERS}"
+                        USERCOUNT=$((USERCOUNT+1))
+                fi
+        done < $USERLIST
+done < $DHCP
+
+# Returns the number of active whitelisted users and sums up multiple devices with the same nick
+echo $USERCOUNT
+echo $USERS|cut -d',' -f -${USERCOUNT}

--- a/generate_spaceapi
+++ b/generate_spaceapi
@@ -31,6 +31,15 @@ else
         fi
 fi
 
+if [ $(/usr/share/bytespeicher/connected_users | sed -n 1p) -eq 0 ]
+then
+        onlineusercount="0"
+        onlineuserlist=""
+else
+        onlineusercount=$(/usr/share/bytespeicher/connected_users | sed -n 1p)
+        onlineuserlist=$(/usr/share/bytespeicher/connected_users | sed -n 2p)
+fi
+
 lastchange=$(/usr/share/bytespeicher/connected_devices --last-change)
 
 cat <<EOL
@@ -72,6 +81,14 @@ cat <<EOL
         "icon": {
                 "open": "$imgopen",
                 "closed": "$imgclosed"
+        },
+        "sensors": {
+                "people_now_present": [
+                {
+                "value": $onlineusercount,
+                "names": [ $onlineuserlist ]
+                }
+                ]
         }
 }
 EOL

--- a/userlist.txt
+++ b/userlist.txt
@@ -1,0 +1,1 @@
+aa:bb:cc:dd:ee:ff Nickname


### PR DESCRIPTION
Proposal for #1 with an opt-in userlist with MAC addresses and nicks. The file `connected_users` reads the whitelist and compares the entries with the DHCP leasefile. Matches are displayed with the nickname. Multiple devices per nick are combined.

The users are shown in the sensors:people_now_present parameter of the Space API:

        "sensors": {
                "people_now_present": [
                {
                "value": 1,
                "names": [ "Suicider" ]
                }
                ]
        }

Now it's also possible to extend Bytespeicher/Bytebot#11 by reading people_now_present.